### PR TITLE
fix: resolve VSIX file path before publishing extensions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,17 @@ jobs:
         with:
           name: release-assets
           path: dist
+      - name: Find VSIX file
+        id: vsix
+        run: echo "file=$(ls dist/*.vsix)" >> $GITHUB_OUTPUT
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.vsix.outputs.file }}
       - name: Publish to VS Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.vsix.outputs.file }}


### PR DESCRIPTION
Fixes ENOENT error where HaaLeo/publish-vscode-extension was not expanding the glob pattern in extensionFile. Adds a step to find the actual VSIX file path first.