### PR TITLE
fix: skip duplicate when publishing VSCode extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,17 @@ jobs:
         with:
           name: release-assets
           path: dist
+      - name: Find VSIX file
+        id: vsix
+        run: echo "file=$(ls dist/*.vsix)" >> $GITHUB_OUTPUT
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.vsix.outputs.file }}
       - name: Publish to VS Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: dist/*.vsix
+          extensionFile: ${{ steps.vsix.outputs.file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,11 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: ${{ steps.vsix.outputs.file }}
+          skipDuplicate: true
       - name: Publish to VS Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{ steps.vsix.outputs.file }}
+          skipDuplicate: true


### PR DESCRIPTION
Add skipDuplicate: true to both publish steps to handle retries gracefully when the extension was already published to a registry.