### PR TITLE
fix: linter install check

### DIFF
--- a/src/api-linter.ts
+++ b/src/api-linter.ts
@@ -91,10 +91,10 @@ export class APILinter {
     this.#isInstallationChecked = true;
     const result = cp.spawnSync(
       this.#command[0],
-      [...this.#command.slice(1), "-h"],
+      [...this.#command.slice(1), "--version"],
       { cwd: this.#workspacePath, encoding: "utf-8" }
     );
-    this.#isInstalled = result.status === 2;
+    this.#isInstalled = result.status === 0;
     return this.#isInstalled;
   }
 


### PR DESCRIPTION
Fixes #77

https://linter.aip.dev/#usage

Use `--version` command for checking the linter. I expect it should have exit code `0` for old and new linter version.