### PR TITLE
fix: linter install check

### DIFF
--- a/src/api-linter.ts
+++ b/src/api-linter.ts
@@ -91,10 +91,10 @@ export class APILinter {
     this.#isInstallationChecked = true;
     const result = cp.spawnSync(
       this.#command[0],
-      [...this.#command.slice(1), "-h"],
+      [...this.#command.slice(1), "--version"],
       { cwd: this.#workspacePath, encoding: "utf-8" }
     );
-    this.#isInstalled = result.status === 2;
+    this.#isInstalled = result.status === 0;
     return this.#isInstalled;
   }
 


### PR DESCRIPTION
Merges the fix from #78 (by @AlexCannonball), rebased onto main after #125.

Fixes #77

Use `--version` instead of `-h` to detect whether api-linter is installed (exit code 0).

Co-authored-by: Aliaksandr <42497203+AlexCannonball@users.noreply.github.com>

Made with [Cursor](https://cursor.com)