### PR TITLE
fix: align engines.vscode with @types/vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "onLanguage:proto3"
   ],
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.120.0"
   },
   "packageManager": "pnpm@11.3.0"
 }


### PR DESCRIPTION
Fixes release workflow failure: @types/vscode ^1.120.0 requires engines.vscode ^1.120.0.

Made with [Cursor](https://cursor.com)