### PR TITLE
fix: emit extension.js for VS Code packaging

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   external: ["vscode"],
   format: "cjs",
   outDir: "dist",
+  outExtension({ format }) {
+    return { js: format === "cjs" ? ".js" : ".mjs" };
+  },
   sourcemap: true,
   target: "esnext",
 });


### PR DESCRIPTION
tsup outputs .cjs when package type is module; vsce expects dist/extension.js per package.json main.

Made with [Cursor](https://cursor.com)