### PR TITLE
fix: point extension entry at .cjs for ESM package type

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "publisher": "mathematic",
   "type": "module",
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "scripts": {
     "vscode:prepublish": "pnpm run package",
     "build": "tsup",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,9 +5,6 @@ export default defineConfig({
   external: ["vscode"],
   format: "cjs",
   outDir: "dist",
-  outExtension({ format }) {
-    return { js: format === "cjs" ? ".js" : ".mjs" };
-  },
   sourcemap: true,
   target: "esnext",
 });


### PR DESCRIPTION
## Summary
- Reverts the tsup `outExtension` override that renamed CJS output to `.js`
- Points `package.json` `main` at `./dist/extension.cjs`

With `"type": "module"` in `package.json`, Node treats `.js` files as ESM. The extension is built as CommonJS, so loading `dist/extension.js` fails with `ReferenceError: module is not defined in ES module scope` and the extension never activates.

Fixes #135

## Test plan
- [x] `pnpm build` emits `dist/extension.cjs` (not `.js`)
- [x] `pnpm lint` passes
- [ ] Install the VSIX locally and open a `proto3` file — extension activates without extension host errors


Made with [Cursor](https://cursor.com)